### PR TITLE
Add support for QHM and QHAdam

### DIFF
--- a/headers/animation.h
+++ b/headers/animation.h
@@ -101,7 +101,7 @@ public:
     {
         name = "Gradient Descent";
         num_states = 4;
-        ball_color = kGradientColor;
+        ball_color = Qt::cyan;
         ball = std::unique_ptr<Ball>(new Ball(m_graph, ball_color, f));
         descent = std::unique_ptr<GradientDescent>(new VanillaGradientDescent);
     };
@@ -134,6 +134,30 @@ protected:
                                   -descent->delta().z / descent->learning_rate);}
 };
 
+class QHMAnimation : public Animation {
+public:
+    QHMAnimation( Q3DSurface *_graph, QTimer *_timer )
+        : Animation( _graph, _timer )
+    {
+        name = "QHM";
+        num_states = 6;
+        ball_color = Qt::red;
+        ball = std::unique_ptr<Ball>( new Ball( m_graph, ball_color, f ) );
+        descent = std::unique_ptr<GradientDescent>( new QHM );
+        has_momentum = true;
+    };
+
+    QString animateStep();
+
+protected:
+    Point momentum()
+    {
+        return Point(
+                -descent->delta().x / descent->learning_rate,
+                -descent->delta().z / descent->learning_rate );
+    }
+};
+
 
 class AdaGradAnimation : public Animation
 {
@@ -143,7 +167,7 @@ public:
     {
         name = "Adagrad";
         num_states = 6;
-        ball_color = Qt::white;
+        ball_color = Qt::gray;
         ball = std::unique_ptr<Ball>(new Ball(m_graph, ball_color, f));
         descent = std::unique_ptr<GradientDescent>(new AdaGrad);
         has_gradient_squared = true;
@@ -207,10 +231,43 @@ protected:
     int interval() {return 5000;}
 
     Point momentum() {
-        return dynamic_cast<Adam*> (descent.get())->decayedGradSum();} 
+        return dynamic_cast<Adam*> (descent.get())->decayedGradSum();}
     Point gradSumOfSquared(){
         return dynamic_cast<Adam*> (descent.get())->decayedGradSumOfSquared();}
 
 };
 
+class QHAdamAnimation : public Animation {
+public:
+    QHAdamAnimation( Q3DSurface *_graph, QTimer *_timer )
+        : Animation( _graph, _timer )
+    {
+        name = "QHAdam";
+        num_states = 9;
+        ball_color = Qt::darkCyan;
+        ball = std::unique_ptr<Ball>( new Ball( m_graph, ball_color, f ) );
+        descent = std::unique_ptr<GradientDescent>( new QHAdam );
+        has_momentum = true;
+        has_gradient_squared = true;
+    };
+
+    QString animateStep();
+
+protected:
+    // scale up the arrow, otherwise you can't see because adagrad moves so slow
+    const float arrowScale = 1;
+    int interval()
+    {
+        return 5000;
+    }
+
+    Point momentum()
+    {
+        return dynamic_cast<QHAdam *>( descent.get() )->decayedGradSum();
+    }
+    Point gradSumOfSquared()
+    {
+        return dynamic_cast<QHAdam *>( descent.get() )->decayedGradSumOfSquared();
+    }
+};
 #endif // ANIMATION_H

--- a/headers/gradient_descent.h
+++ b/headers/gradient_descent.h
@@ -64,10 +64,24 @@ class Momentum : public GradientDescent {
 public:
     Momentum() {}
 
-    double decay_rate = 0.8;
+    double decay_rate = 0.9;
 
 protected:
     void updateGradientDelta();
+};
+
+class QHM : public GradientDescent {
+public:
+    QHM(): momentum( 0., 0.) { }
+
+    double decay_rate = 0.990;     // beta
+    double discount_factor = 0.7;  // v
+
+protected:
+    void updateGradientDelta() override;
+    void resetState() override;
+private:
+    Point momentum;
 };
 
 class AdaGrad : public GradientDescent {
@@ -100,22 +114,41 @@ private:
 
 class Adam : public GradientDescent {
 public:
-    Adam() : decayed_grad_sum(0., 0.),
-        decayed_grad_sum_of_squared(0., 0.)
-    {}
+    Adam()
+        : decayed_grad_sum( 0., 0. )
+        , decayed_grad_sum_of_squared( 0., 0. )
+        , beta1_pow( beta1 )
+        , beta2_pow( beta2 )
+    { }
 
     double beta1 = 0.9;
     double beta2 = 0.999;
+    bool use_bias_correction = true;
+
     Point decayedGradSum(){return decayed_grad_sum;}
     Point decayedGradSumOfSquared(){return decayed_grad_sum_of_squared;}
 
 protected:
-    void updateGradientDelta();
-    void resetState();
+    void baseCompute( Point &scaled_decayed_grad_sum, Point &scaled_decayed_grad_sum_sq );
+    void updateGradientDelta() override;
+    void resetState() override;
 
 private:
     Point decayed_grad_sum;
     Point decayed_grad_sum_of_squared;
+    double beta1_pow;
+    double beta2_pow;
+};
+
+class QHAdam : public Adam {
+public:
+    QHAdam() {}
+
+    double discount_factor = 0.7;         // v1
+    double squared_discount_factor = 1.0; // v2
+
+protected:
+    void updateGradientDelta() override;
 };
 
 #endif // GRADIENTDESCENT_H

--- a/headers/plot_area.h
+++ b/headers/plot_area.h
@@ -22,10 +22,12 @@ public:
     ~PlotArea();
     std::unique_ptr<Animation> gradient_descent;
     std::unique_ptr<Animation> momentum;
+    std::unique_ptr<Animation> qhm;
     std::unique_ptr<Animation> ada_grad;
     std::unique_ptr<Animation> rms_prop;
     std::unique_ptr<Animation> adam;
-    std::vector<Animation*> all_animations;
+    std::unique_ptr<Animation> qhadam;
+    std::vector<Animation *> all_animations;
 
 signals:
     void updateMessage(QString message);

--- a/headers/window.h
+++ b/headers/window.h
@@ -46,9 +46,11 @@ private:
         QFormLayout* layout);
     QGroupBox* createGradientDescentGroup();
     QGroupBox* createMomentumGroup();
-    QGroupBox* createAdaGradGroup();
+    QGroupBox *createQHMGroup();
+    QGroupBox *createAdaGradGroup();
     QGroupBox* createRMSPropGroup();
     QGroupBox* createAdamGroup();
+    QGroupBox *createQHAdamGroup();
 
     QLayout* createLearningRateBox(GradientDescent* descent);
     QDoubleSpinBox* createDecayBox(double& val);
@@ -56,4 +58,3 @@ private:
 };
 
 #endif
-

--- a/src/plot_area.cpp
+++ b/src/plot_area.cpp
@@ -79,19 +79,19 @@ void PlotArea::initializeAnimations(){
                 new GradientDescentAnimation(m_graph.get(), &m_timer));
     momentum = std::unique_ptr<Animation>(
                 new MomentumAnimation(m_graph.get(), &m_timer));
+    qhm = std::unique_ptr<Animation>(
+            new QHMAnimation( m_graph.get(), &m_timer ) );
     ada_grad = std::unique_ptr<Animation>(
-                new AdaGradAnimation(m_graph.get(), &m_timer));
+            new AdaGradAnimation( m_graph.get(), &m_timer ) );
     rms_prop = std::unique_ptr<Animation>(
                 new RMSPropAnimation(m_graph.get(), &m_timer));
     adam = std::unique_ptr<Animation>(
                 new AdamAnimation(m_graph.get(), &m_timer));
-    all_animations = {
-        gradient_descent.get(),
-        momentum.get(),
-        ada_grad.get(),
-        rms_prop.get(),
-        adam.get()
-    };
+    qhadam = std::unique_ptr<Animation>(
+            new QHAdamAnimation( m_graph.get(), &m_timer ) );
+    all_animations
+            = { gradient_descent.get(), momentum.get(), qhm.get(),
+                    ada_grad.get(), rms_prop.get(), adam.get(), qhadam.get() };
 }
 
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -37,9 +37,11 @@ Window::Window(QWidget *parent)
     // widgets to tune gradient parameters
     vLayout->addWidget(createGradientDescentGroup());
     vLayout->addWidget(createMomentumGroup());
+    vLayout->addWidget(createQHMGroup());
     vLayout->addWidget(createAdaGradGroup());
     vLayout->addWidget(createRMSPropGroup());
-    vLayout->addWidget(createAdamGroup(), 1, Qt::AlignTop);
+    vLayout->addWidget(createAdamGroup());
+    vLayout->addWidget( createQHAdamGroup(), 1, Qt::AlignTop );
 
     setupKeyboardShortcuts();
 }
@@ -205,6 +207,23 @@ QGroupBox *Window::createMomentumGroup(){
     return createDescentGroup(plot_area->momentum.get(), form);
 }
 
+QGroupBox *Window::createQHMGroup()
+{
+    QHM *descent = dynamic_cast<QHM *>( plot_area->qhm->descent.get() );
+
+    QFormLayout *form = new QFormLayout;
+    form->addRow(
+            new QLabel( QStringLiteral( "Learning Rate:" ) ),
+            createLearningRateBox( descent ) );
+    form->addRow(
+            new QLabel( QStringLiteral( "Decay rate:" ) ),
+            createDecayBox( descent->decay_rate ) );
+    form->addRow(
+            new QLabel( QStringLiteral( "Discount factor:" ) ),
+            createDecayBox( descent->discount_factor ) );
+
+    return createDescentGroup( plot_area->qhm.get(), form );
+}
 
 QGroupBox *Window::createAdaGradGroup(){
     AdaGrad* descent = dynamic_cast<AdaGrad*> (plot_area->ada_grad->descent.get());
@@ -241,9 +260,49 @@ QGroupBox *Window::createAdamGroup(){
     form->addRow(new QLabel(QStringLiteral("Beta2:")),
                  createDecayBox(descent->beta2));
 
+    QCheckBox *scaled = new QCheckBox( "Use Bias Correction" );
+    auto &bias_val = descent->use_bias_correction;
+    scaled->setChecked( bias_val );
+    QObject::connect( scaled, &QCheckBox::clicked, [&]( bool clicked ) {
+                bias_val = clicked;
+            } );
+    form->addRow( scaled );
+
     return createDescentGroup(plot_area->adam.get(), form);
 }
 
+
+QGroupBox *Window::createQHAdamGroup()
+{
+    QHAdam *descent = dynamic_cast<QHAdam *>( plot_area->qhadam->descent.get() );
+
+    QFormLayout *form = new QFormLayout;
+    form->addRow(
+            new QLabel( QStringLiteral( "Learning Rate:" ) ),
+            createLearningRateBox( descent ) );
+    form->addRow(
+            new QLabel( QStringLiteral( "Beta1:" ) ),
+            createDecayBox( descent->beta1 ) );
+    form->addRow(
+            new QLabel( QStringLiteral( "Beta2:" ) ),
+            createDecayBox( descent->beta2 ) );
+    form->addRow(
+            new QLabel( QStringLiteral( "Discount Factor:" ) ),
+            createDecayBox( descent->discount_factor ) );
+    form->addRow(
+            new QLabel( QStringLiteral( "Sq Discount Factor:" ) ),
+            createDecayBox( descent->squared_discount_factor ) );
+
+    QCheckBox *scaled = new QCheckBox( "Use Bias Correction" );
+    auto &bias_val = descent->use_bias_correction;
+    scaled->setChecked( bias_val );
+    QObject::connect( scaled, &QCheckBox::clicked, [&]( bool clicked ) {
+                bias_val = clicked;
+            } );
+    form->addRow( scaled );
+
+    return createDescentGroup( plot_area->qhadam.get(), form );
+}
 
 QLayout *Window::createLearningRateBox(GradientDescent* descent){
     // learning rate spin box


### PR DESCRIPTION
QHM and QHAdam are enhancements to the standard Momentum and Adam algorithms respectively. See the paper: [Quasi-Hyperbolic Momentum and Adam for Deep Learning](https://arxiv.org/abs/1810.06801v4) for more details. I have added these two algorithms to interface.

QHM adds a hyperparameter `v`, also known as the `discount factor` in addition to the momentum or `decay` hyperparameter used by the momentum algorithm. QHM can be configured with these parameters to exactly implement several common gradient descent algorithms.
- **Momentum**: When `v` is 1, QHM is identical to momentum.
- **SGD**: When `v` is 0 and 'decay' is 1, QHM is identical to the gradient descent algorithm.
- **Nesterov**: When `v` and `decay` are set to the same value, QHM is identical to Nesterov's accelerated gradient. It can also be used identically to Synthesized Nesterov Variants including the Robust Momentum method.

The basic Adam implementation and the one currently implemented in this code, prior to this PR, is biased towards zero. The [Gradient Descent Wikipedia article](https://en.wikipedia.org/wiki/Stochastic_gradient_descent#Adam) referenced in the source code specifies a bias correction. I have added a _hyperparameter_ to the UI to allow the user to enable bias correction.

QHAdam adds two hyperparamters `v1`, also known as the `discount factor` and `v2`, also known as the `squared discount factor` to the two Adam hyperparameters, `beta1` and `beta2`, plus the `bias correction` option. QHAdam can be configured with these parameters to exactly implement several gradient descent algorithms.
- **Adam**: When `v1` and `v2` are both 1, QHAdam is identical to Adam.
- **RMSProp**: When `v1` is 0, `v2` is 1 and `bias correction` is disabled, QHAdam is identical to RMSProp.
- **NAdam**: When `v1` and `beta1` have the same value and `v2` is 1, QHAdam is identical to NAdam.